### PR TITLE
[#69] Fix: Base64URL valid characters are not properly validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+- [#69] Fix: Base64URL valid characters are not properly validated
+- [#67] Add SECURITY.md
+
 ## [0.1.0-beta.9] - 2024-09-03
 
 - [#64] maintain iOS 15 compatibility

--- a/Sources/ZcashPaymentURI/Model.swift
+++ b/Sources/ZcashPaymentURI/Model.swift
@@ -89,7 +89,8 @@ public struct MemoBytes: Equatable {
         
         self.data = Data(bytes)
     }
-    
+    /// Initializes a Memo from a UTF8 String.
+    /// - Important: use [`MemoBytes.init(base64URL:)`] to initialize a memo from base64URL
     public init(utf8String: String) throws {
         guard !utf8String.isEmpty else {
             throw MemoError.memoEmpty
@@ -106,7 +107,17 @@ public struct MemoBytes: Equatable {
         self.data = memoStringData
     }
 
+    /// Initializes a [`MemoBytes`] from a [RFC 4648   Base64URL](https://datatracker.ietf.org/doc/html/rfc4648#section-5)
+    /// string.
+    /// - parameter base64URL: a String confirming to the Base64URL specification
+    /// - throws [`MemoBytes.MemoError.invalidBase64URL`] if an invalid string is found.
     public init(base64URL: String) throws {
+        guard base64URL.unicodeScalars.allSatisfy({ character in
+            CharacterSet.base64URL.contains(character)
+        }) else {
+            throw MemoBytes.MemoError.invalidBase64URL
+        }
+
         var base64 = base64URL.replacingOccurrences(of: "_", with: "/")
             .replacingOccurrences(of: "-", with: "+")
         
@@ -251,4 +262,12 @@ extension CharacterSet {
                 "}"
             )
         )
+
+    /// [RFC 4648  Base64URL](https://www.rfc-editor.org/rfc/rfc4648.html#section-5) Character Set.
+    /// A-Z, a-z, 0-9, _, -
+    /// - Note: a Base64URL value can be defined using the following regular expression:
+    /// ^[A-Za-z0-9_-]+$
+    static let base64URL = ASCIINum
+        .union(.ASCIIAlpha)
+        .union(CharacterSet(arrayLiteral: "-", "_"))
 }

--- a/Sources/ZcashPaymentURI/Model.swift
+++ b/Sources/ZcashPaymentURI/Model.swift
@@ -107,7 +107,7 @@ public struct MemoBytes: Equatable {
         self.data = memoStringData
     }
 
-    /// Initializes a [`MemoBytes`] from a [RFC 4648   Base64URL](https://datatracker.ietf.org/doc/html/rfc4648#section-5)
+    /// Initializes a [`MemoBytes`] from an [RFC-4648 Base64URL](https://datatracker.ietf.org/doc/html/rfc4648#section-5)
     /// string.
     /// - parameter base64URL: a String confirming to the Base64URL specification
     /// - throws [`MemoBytes.MemoError.invalidBase64URL`] if an invalid string is found.

--- a/Tests/ZcashPaymentURITests/MemoBytesTests.swift
+++ b/Tests/ZcashPaymentURITests/MemoBytesTests.swift
@@ -58,4 +58,10 @@ final class MemoBytesTests: XCTestCase {
         
         XCTAssertThrowsError(try MemoBytes(bytes: [UInt8](repeating: 0xf4, count: 513)))
     }
+
+    func testInitWithInvalidTextFails() throws {
+        let invalidCharactersMemo = "QTw+Qg"
+
+        XCTAssertThrowsError(try MemoBytes(base64URL: invalidCharactersMemo))
+    }
 }

--- a/Tests/ZcashPaymentURITests/MemoBytesTests.swift
+++ b/Tests/ZcashPaymentURITests/MemoBytesTests.swift
@@ -38,6 +38,22 @@ final class MemoBytesTests: XCTestCase {
         XCTAssertEqual(memo.toBase64URL(), expectedBase64)
     }
 
+    /// Cross-check using all Base64URL characters and do a round-trip
+    func testRoundTripWithAllBase64URLCharacters() throws {
+        let base64URLCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+        let e: [UInt8] = [
+            0x00, 0x10, 0x83, 0x10, 0x51, 0x87, 0x20, 0x92, 0x8b, 0x30, 0xd3, 0x8f, 0x41, 0x14, 0x93, 0x51,
+            0x55, 0x97, 0x61, 0x96, 0x9b, 0x71, 0xd7, 0x9f, 0x82, 0x18, 0xa3, 0x92, 0x59, 0xa7, 0xa2, 0x9a,
+            0xab, 0xb2, 0xdb, 0xaf, 0xc3, 0x1c, 0xb3, 0xd3, 0x5d, 0xb7, 0xe3, 0x9e, 0xbb, 0xf3, 0xdf, 0xbf
+        ]
+
+        let memo = try MemoBytes(base64URL: base64URLCharacters)
+        let memoFromBytes = try MemoBytes(bytes: e)
+
+        XCTAssertEqual(memo, memoFromBytes)
+        XCTAssertEqual(memo.toBase64URL(), base64URLCharacters)
+    }
+
     func testUnicodeMemo() throws {
         let memoUTF8Text = "This is a unicode memo ✨🦄🏆🎉"
         let expectedBase64 = "VGhpcyBpcyBhIHVuaWNvZGUgbWVtbyDinKjwn6aE8J-PhvCfjok"

--- a/Tests/ZcashPaymentURITests/ZIP321Tests.swift
+++ b/Tests/ZcashPaymentURITests/ZIP321Tests.swift
@@ -134,4 +134,10 @@ final class ZcashSwiftPaymentUriTests: XCTestCase {
 
         XCTAssertNoDifference(result, ParserResult.request(paymentRequest))
     }
+
+    func testURIRequestWithInvalidCharsFails() throws {
+        let invalidBase64URI = "zcash:u19spl3y4zu73twemxrzm33tm3eefepecv4zdssn0hfd4tjaqpgmlcm9nhyjqlvaytwpknqjqctvdscjmg47ex20j03cu4gx3zmy26y2hunpenvw083dmtlq4y7re5rwsygpteq57wwllr3zhs4rw43j5puxgrcqdq4f9dd38qksl4f9p2hc7x3kj582zdjxsnj8urmnc3msfjw72kej0?amount=0.01&memo=QTw+Qg"
+
+        XCTAssertThrowsError(try ZIP321.request(from: invalidBase64URI))
+    }
 }


### PR DESCRIPTION
as reported by @daira Base64URL character set was not being enforced when creating a MemoBytes value from a supposedly base64URL.

This PR introduces such validation and tests that exercise that logic
closes #69 